### PR TITLE
Compatibility with MDL 2.6 and MDL 2.9

### DIFF
--- a/src/server/mod_form.php
+++ b/src/server/mod_form.php
@@ -82,7 +82,14 @@ class mod_elang_mod_form extends moodleform_mod
 		$mform->addHelpButton('name', 'elangname', 'elang');
 
 		// Adding the standard "intro" and "introformat" fields
-		$this->add_intro_editor($config->requiremodintro);
+		if (version_compare(moodle_major_version(true), '2.9', '>='))
+		{
+			$this->standard_intro_elements();
+		}
+		else
+		{
+			$this->add_intro_editor($config->requiremodintro);
+		}
 
 		// Adding the rest of elang settings, spreeading all them into this fieldset
 		$mform->addElement('header', 'elangfieldset', get_string('upload', 'elang'));

--- a/src/server/server.php
+++ b/src/server/server.php
@@ -350,7 +350,7 @@ switch ($task)
 				)
 			);
 
-			if (version_compare($version, '2.6') < 0)
+			if (version_compare($version, '2.7') < 0)
 			{
 				add_to_log($course->id, 'elang', 'add check', 'view.php?id=' . $cm->id, $check_id, $cm->id);
 			}
@@ -471,7 +471,7 @@ switch ($task)
 			)
 		);
 
-		if (version_compare($version, '2.6') < 0)
+		if (version_compare($version, '2.7') < 0)
 		{
 			add_to_log($course->id, 'elang', 'view help', 'view.php?id=' . $cm->id, $help_id, $cm->id);
 		}

--- a/src/server/settings.php
+++ b/src/server/settings.php
@@ -24,14 +24,18 @@ if ($ADMIN->fulltree)
 	$languages = Elang\getLanguages();
 
 	// General settings
-	$settings->add(
-		new admin_setting_configcheckbox(
-			'elang/requiremodintro',
-			get_string('requiremodintro', 'admin'),
-			get_string('configrequiremodintro', 'admin'),
-			1
-		)
-	);
+	if (version_compare(moodle_major_version(true), '2.8', '<'))
+	{
+		// This should be present only until Moodle 2.7.x
+		$settings->add(
+			new admin_setting_configcheckbox(
+				'elang/requiremodintro',
+				get_string('requiremodintro', 'elang'),
+				get_string('configrequiremodintro', 'elang'),
+				1
+			)
+		);
+	}
 
 	$settings->add(
 		new admin_setting_configtext(


### PR DESCRIPTION
The following patches fix several debugging notifications as well as the problem on MDL 2.6.x, that Listening Landscape does not check nor give hints for filling the gaps. Instead it delivers a 404 errror message.