### PR TITLE
Code fragment for encoding-conversion of the subtitle files via iconv

### DIFF
--- a/src/server/lang/en/elang.php
+++ b/src/server/lang/en/elang.php
@@ -101,6 +101,7 @@ $string['studentsuccess'] = 'Success';
 $string['studenttitle'] = 'Title';
 $string['subtitle_help'] = 'Upload a file with UTF-8 encoding usinf srt or webvtt format';
 $string['subtitleinvalidformat'] = 'Invalid subtitle file format';
+$string['subtitleunknownencoding'] = 'Not able to detect the encoding of your subtitle file. Please convert this file first to UTF-8 and try again!';
 $string['subtitlemaxsize_config'] = 'Set the maximum subtitle size in bytes';
 $string['subtitlemaxsize'] = 'Maximum subtitle size';
 $string['subtitleunabletosave'] = 'Unable to save subtitle file. Contact your administrator.';

--- a/src/server/locallib.php
+++ b/src/server/locallib.php
@@ -18,7 +18,9 @@ namespace Elang;
 
 defined('MOODLE_INTERNAL') || die();
 
+# **** Which file does this line refer to? ****
 require_once dirname(__FILE__) . '/vendor/autoload.php';
+# **** Which file does this line refer to? ****
 
 /**
  * Send a json response
@@ -161,7 +163,9 @@ function saveFiles(\stdClass $elang, \mod_elang_mod_form $mform)
 {
 	global $DB;
 
-	require_once dirname(__FILE__) . '/locallib.php';
+	# This line refers to the same file
+	// require_once dirname(__FILE__) . '/locallib.php';
+	# This line refers to the same file
 
 	$id = $elang->id;
 	$cmid = $elang->coursemodule;

--- a/src/server/mod_form.php
+++ b/src/server/mod_form.php
@@ -301,6 +301,8 @@ class mod_elang_mod_form extends moodleform_mod
 			}
 			catch (\Exception $e)
 			{
+				$errors['subtitle'] = $e;
+				break;
 			}
 
 			try
@@ -311,6 +313,8 @@ class mod_elang_mod_form extends moodleform_mod
 			}
 			catch (\Exception $e)
 			{
+				$errors['subtitle'] = $e;
+				break;
 			}
 		}
 


### PR DESCRIPTION
This is part of a code fragment for reencode subtitle files to utf-8

This is the code, I finally ended with. However, as locallib.php seems not to match the other files I did not find a way to implement this. Now, the subtitles are not handled by a string but by a temporary file in the moodledata folder...

So, it has to be implemented into the \Captioning\Format class (which seems not to exist at the moment) and has to be called in the constructor imho

/**
 * Detect and transcode encoding of a string into UTF-8 or another given encoding
 * (using iconv instead the less reliable mb_convert_encoding)
 *
 * @param   string               $contents  the string to be analysed and to be converted (as reference)
 * @param   string               $contents  the string to be analysed and to be converted (as reference)
 *
 * @return bool
 *
 * @since  1.1.0
 */
function transcodesubtitle (string &$contents, string $encoding_to = "UTF-8")
{
	// $encoding_to is explicitely given as null, there is nothing to do
	if (!$encoding_to) 
	{
		return false;
		break;
	}

	// set the assumed encoding of the string as false
	$encoding = false;

	// Detect bom for different encodings and strip it from the string
	$bom_encoding = array('UTF-32BE' => pack("CCCC", 0x00, 0x00, 0xFE, 0xFF),
	'UTF-32LE' => pack("CCCC", 0xFF, 0xFE, 0x00, 0x00),
	'GB-18030' => pack("CCCC", 0x84, 0x31, 0x95, 0x33),
	'UTF-8' => pack("CCC", 0xEF, 0xBB, 0xBF),
	'UTF-16BE' => pack("CC", 0xFE, 0xFF),
	'UTF-16LE' => pack("CC", 0xFF, 0xFE));
	
	foreach ($bom_encoding AS $enc => $bom)
	{
		if (0 == strncmp($contents, $bom, strlen($bom)))
		{
			$contents = substr($contents, strlen($bom));
			$encoding = $enc;
			break;
		}
	}
	
	if (!$encoding)
	{
		// Try to detect concurrent encoding and convert into UTF-8
		
		$detect_order = array( 'ASCII', 'UTF-8', 'UCS-2', 'UCS-2BE', 'UCS-2LE', 'UCS-4', 'UCS-4BE', 'UCS-4LE', 'UTF-16', 'UTF-16BE', 'UTF-16LE', 'UTF-32', 'UTF-32BE', 'UTF-32LE', 'ISO-8859-1', 'ISO-8859-2', 'ISO-8859-3', 'ISO-8859-4', 'ISO-8859-5', 'ISO-8859-6', 'ISO-8859-7', 'ISO-8859-8', 'ISO-8859-9', 'ISO-8859-10', 'ISO-8859-11', 'ISO-8859-13', 'ISO-8859-14', 'ISO-8859-15', 'ISO-8859-16', 'KOI8-R', 'KOI8-U', 'KOI8-RU', 'WINDOWS-1250', 'WINDOWS-1251', 'WINDOWS-1252', 'WINDOWS-1253', 'WINDOWS-1254', 'WINDOWS-1255', 'WINDOWS-1256', 'WINDOWS-1257', 'WINDOWS-1258', 
		'MACROMAN', 'MACCENTRALEUROPE', 'MACICELAND', 'MACCROATIAN', 'MACROMANIA', 'MACCYRILLIC', 'MACUKRAINE', 'MACGREEK', 'MACTURKISH', 'MACHEBREW', 'MACARABIC', 'MACTHAI', 'KOI8-T', 'ISO-IR-166', 'WINDOWS-874', 
		'ISO-IR-14', 'JISX0201-1976', 'ISO-IR-87', 'ISO-IR-159', 'GB_1988-80', 'GB_2312-80', 'ISO-IR-149', 'EUC-JP', 'SHIFT-JIS', 'ISO-2022-JP', 'ISO-2022-JP-1', 'ISO-2022-JP-2', 'EUC-CN', 'GBK', 'WINDOWS-936', 'GB18030', 'ISO-2022-CN', 'BIG-5', 'CP950','EUC-KR', 'ISO-2022-KR', 'DEC-KANJI', 'DEC-HANYU', 'EUC-JISX0213', 'SHIFT_JISX0213', 'ISO-2022-JP-3');
		
		// Test for all encodings given above
		foreach ($detect_order AS $enc)
		{
			$enc_contents = @iconv ($enc, $enc, $contents);
			if (($enc_contents) AND ($contents == $enc_contents))
			{
				$encoding = $enc;
				break;
			}
		}				
	}
	
	// Convert the encoding
	if ($encoding)
	{
		$contents = iconv ($encoding, $encoding_to."//IGNORE", $contents);
		return true;
	}
	else
	{
		// Throw user-friendly error (How to do that actually???)
		return false;
		# For the moment, there should be a standard error page with a meaningful description 	
		print_error(get_string('subtitleunknownencoding', 'elang'), 'elang');
		# new Exception('subtitleunknownencoding');
		# die ('Encoding of the subtitle file not detectible. Please try to convert this first to UTF-8.!');
	}
}