### PR TITLE
Switching easily to student's view for teachers

### DIFF
--- a/src/server/lang/en/elang.php
+++ b/src/server/lang/en/elang.php
@@ -85,6 +85,7 @@ $string['settings'] = 'Specific module settings';
 $string['showlanguage_config'] = 'Show the language in the course module title';
 $string['showlanguage_help'] = 'Show the language in the course module title';
 $string['showlanguage'] = 'Show language';
+$string['showplayer'] = 'Display student\'s view';
 $string['size_config'] = 'This defines the pdf font size';
 $string['size_error'] = 'You should enter a number here. Typical value is 16.';
 $string['size_help'] = 'This defines the pdf font size';

--- a/src/server/report.php
+++ b/src/server/report.php
@@ -415,6 +415,16 @@ else
 			// Set default data (if any)
 			$mform->set_data($toform);
 		}
+	
+		// Display link to the player
+		echo html_writer::link(
+				new moodle_url(
+					'/mod/elang/view.php',
+					array('id' => $cm->id, 'view' => 'player')
+				),
+				get_string('showplayer', 'elang'),
+				array('target' => '_blank')
+			).'&nbsp;&nbsp;&nbsp;';
 
 		// Display download link
 		if ($id_group != 0)

--- a/src/server/view.php
+++ b/src/server/view.php
@@ -23,6 +23,10 @@ $version = moodle_major_version(true);
 // Get the course number
 $id = required_param('id', PARAM_INT);
 
+// Get the optional view parameter
+$view = optional_param('view',NULL, PARAM_ALPHA);
+// 'player' for player view for teachers
+
 // Get the course module
 $cm = get_coursemodule_from_id('elang', $id, 0, false, MUST_EXIST);
 
@@ -38,7 +42,7 @@ require_login($course, true, $cm);
 // Get the context
 $context = context_module::instance($cm->id);
 
-if (has_capability('mod/elang:report', $context))
+if ((has_capability('mod/elang:report', $context))&&($view != 'player'))
 {
 	require_once dirname(__FILE__) . '/report.php';
 }


### PR DESCRIPTION
At the moment, a teacher can only access the player in case he/she switched roles to student. However, as this procedure is quite 'tricky' (most of the teachers will not know about changing roles or will not understand quickly as it is not obvious), it would be nice to have an easy-to-use access to the player, for example to check it everything is set up alright or in order to show it to their students.

These few code changes reflect those anticipated problems and introduces a link to access the player in report.php .